### PR TITLE
remove Yarp Init check in ICub

### DIFF
--- a/devices/ICub/src/ICub.cpp
+++ b/devices/ICub/src/ICub.cpp
@@ -207,12 +207,6 @@ bool ICub::open(yarp::os::Searchable& config)
         return false;
     }
 
-    // Check YARP network
-    if(!yarp::os::Network::initialized())
-    {
-        yarp::os::Network::init();
-    }
-
     // ===============================
     // PARSE THE CONFIGURATION OPTIONS
     // ===============================


### PR DESCRIPTION
The compilation on `MacOS` and `Windows` was failing with the following error:

```
Undefined symbols for architecture x86_64:
  "yarp::os::Network::init()", referenced from:
      wearable::devices::ICub::open(yarp::os::Searchable&) in ICub.cpp.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

For the moment me and @Yeshasvitvs  decided to remove those lines.