### PR TITLE
Rpc port optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,12 +21,9 @@ endif()
 
 # Libraries type
 if(MSVC)
-    option(BUILD_SHARED_LIBS "Compile WBToolbox as a shared library" OFF)
+    option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" OFF)
 else()
-    option(BUILD_SHARED_LIBS "Compile WBToolbox as a shared library" ON)
-endif()
-if(NOT BUILD_SHARED_LIBS)
-    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+    option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" ON)
 endif()
 
 # Control where binaries and libraries are placed in the build folder.
@@ -63,9 +60,10 @@ add_subdirectory(impl)
 
 # Prepare YARP wrapper and devices
 find_package(YARP 3.0 REQUIRED)
-set(BUILD_SHARED_LIBS ON)
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(YARP_FORCE_DYNAMIC_PLUGINS ON)
 yarp_configure_plugins_installation(wearable)
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 add_subdirectory(msgs)
 add_subdirectory(devices)

--- a/devices/IWearRemapper/include/IWearRemapper.h
+++ b/devices/IWearRemapper/include/IWearRemapper.h
@@ -12,6 +12,7 @@
 #include "Wearable/IWear/IWear.h"
 
 #include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/PreciselyTimed.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/os/TypedReaderCallback.h>
 
@@ -31,6 +32,7 @@ class wearable::devices::IWearRemapper
     , public wearable::IWear
     , public yarp::os::TypedReaderCallback<msg::WearableData>
     , public yarp::os::PeriodicThread
+    , public yarp::dev::IPreciselyTimed
 {
 private:
     class impl;
@@ -50,6 +52,10 @@ public:
     // TypedReaderCallback
     void onRead(msg::WearableData& wearData) override;
 
+    // PreciselyTimed interface
+    yarp::os::Stamp getLastInputStamp() override;
+
+    // IWear interface
     WearableName getWearableName() const override;
     WearStatus getStatus() const override;
     TimeStamp getTimeStamp() const override;
@@ -102,6 +108,7 @@ public:
 
     SensorPtr<const sensor::IVirtualSphericalJointKinSensor>
     getVirtualSphericalJointKinSensor(const sensor::SensorName /*name*/) const override;
+
 };
 
 #endif // IWEARREMAPPER_H

--- a/devices/IWearRemapper/src/IWearRemapper.cpp
+++ b/devices/IWearRemapper/src/IWearRemapper.cpp
@@ -825,6 +825,13 @@ void IWearRemapper::onRead(msg::WearableData& receivedWearData)
     }
 }
 
+yarp::os::Stamp IWearRemapper::getLastInputStamp()
+{
+    std::lock_guard<std::recursive_mutex> lock(pImpl->mutex);
+    // Stamp count should be always zero
+    return yarp::os::Stamp(0, getTimeStamp().time);
+}
+
 WearableName IWearRemapper::getWearableName() const
 {
     std::lock_guard<std::recursive_mutex> lock(pImpl->mutex);

--- a/devices/IWearRemapper/src/IWearRemapper.cpp
+++ b/devices/IWearRemapper/src/IWearRemapper.cpp
@@ -40,6 +40,7 @@ public:
     yarp::os::Network network;
     TimeStamp timestamp;
     bool firstRun = true;
+    bool useRPC = false;
 
     mutable std::recursive_mutex mutex;
 
@@ -135,15 +136,25 @@ bool IWearRemapper::open(yarp::os::Searchable& config)
     }
 
     // RPC ports
-    if (!(config.check("wearableRPCPorts") && config.find("wearableRPCPorts").isList())) {
-        yError() << logPrefix << "wearableRPCPorts option does not exist or it is not a list";
-        return false;
+    // The usage of rpc port is optional depending wether or not the parameter is present
+    yarp::os::Bottle* inputRPCPortsNamesList = nullptr;
+    if (!config.check("wearableRPCPorts"))
+    {
+        yInfo() << logPrefix << "wearableRPCPorts does not exist. RPC port will not be used";
     }
-    yarp::os::Bottle* inputRPCPortsNamesList = config.find("wearableRPCPorts").asList();
-    for (unsigned i = 0; i < inputRPCPortsNamesList->size(); ++i) {
-        if (!inputRPCPortsNamesList->get(i).isString()) {
-            yError() << logPrefix << "ith entry of wearableRPCPorts list is not a string";
+    else
+    {
+        pImpl->useRPC = true;
+        if (!config.find("wearableRPCPorts").isList()) {
+            yError() << logPrefix << "wearableRPCPorts option is not a list";
             return false;
+        }
+        inputRPCPortsNamesList = config.find("wearableRPCPorts").asList();
+        for (unsigned i = 0; i < inputRPCPortsNamesList->size(); ++i) {
+            if (!inputRPCPortsNamesList->get(i).isString()) {
+                yError() << logPrefix << "ith entry of wearableRPCPorts list is not a string";
+                return false;
+            }
         }
     }
 
@@ -168,8 +179,11 @@ bool IWearRemapper::open(yarp::os::Searchable& config)
 
     // Convert list to vector
     std::vector<std::string> inputRPCPortsNamesVector;
-    for (unsigned i = 0; i < inputRPCPortsNamesList->size(); ++i) {
-        inputRPCPortsNamesVector.emplace_back(inputRPCPortsNamesList->get(i).asString());
+    if (pImpl->useRPC)
+    {
+        for (unsigned i = 0; i < inputRPCPortsNamesList->size(); ++i) {
+            inputRPCPortsNamesVector.emplace_back(inputRPCPortsNamesList->get(i).asString());
+        }
     }
 
     yInfo() << logPrefix << "*** ========================";
@@ -177,10 +191,16 @@ bool IWearRemapper::open(yarp::os::Searchable& config)
         yInfo() << logPrefix << "*** Wearable Data Port" << i + 1 << "  :"
                 << inputDataPortsNamesVector[i];
     }
-    for (unsigned i = 0; i < inputDataPortsNamesVector.size(); ++i) {
-        yInfo() << logPrefix << "*** Wearable RPC Port" << i + 1 << "   :"
-                << inputRPCPortsNamesVector[i];
-        ;
+    if (pImpl->useRPC)
+    {
+        for (unsigned i = 0; i < inputDataPortsNamesVector.size(); ++i) {
+            yInfo() << logPrefix << "*** Wearable RPC Port" << i + 1 << "   :"
+                    << inputRPCPortsNamesVector[i];
+        }
+    }
+    else
+    {
+        yInfo() << logPrefix << "*** Wearable RPC Port not configured";
     }
     yInfo() << logPrefix << "*** Output port            :" << outputPortName;
     yInfo() << logPrefix << "*** ========================";
@@ -221,90 +241,93 @@ bool IWearRemapper::open(yarp::os::Searchable& config)
     // ====================
     // OPEN INPUT RPC PORTS
     // ====================
-    yDebug() << logPrefix << "Opening input RPC ports";
+    if(pImpl->useRPC)
+    {
+        yDebug() << logPrefix << "Opening input RPC ports";
 
-    if (inputDataPortsNamesVector.size() != inputRPCPortsNamesVector.size()) {
-        yError() << logPrefix << "wearableDataPorts and wearableRPCPorts lists should contain "
-                 << "the same number of elements.";
-        return false;
-    }
-
-    using SensorTypeMetadata = std::vector<wearable::msg::WearableSensorMetadata>;
-    using WearableMetadata = std::map<wearable::msg::SensorType, SensorTypeMetadata>;
-
-    std::vector<WearableMetadata> metadata;
-
-    // Get metadata from remote rpc ports
-    for (const auto& inputRpcPortName : inputRPCPortsNamesVector) {
-        // Open a local port for the rpc data
-        yarp::os::RpcClient localRpcPort;
-        if (!localRpcPort.open("...")) {
-            yInfo() << logPrefix << "Failed to open local port";
+        if (inputDataPortsNamesVector.size() != inputRPCPortsNamesVector.size()) {
+            yError() << logPrefix << "wearableDataPorts and wearableRPCPorts lists should contain "
+                     << "the same number of elements.";
             return false;
         }
 
-        // Wait the connection with the remote port
-        while (true) {
-            yarp::os::Network::connect(localRpcPort.getName(), inputRpcPortName);
-            if (yarp::os::Network::isConnected(localRpcPort.getName(), inputRpcPortName)) {
-                yInfo() << logPrefix << "Connected with" << inputRpcPortName;
-                break;
+        using SensorTypeMetadata = std::vector<wearable::msg::WearableSensorMetadata>;
+        using WearableMetadata = std::map<wearable::msg::SensorType, SensorTypeMetadata>;
+
+        std::vector<WearableMetadata> metadata;
+
+        // Get metadata from remote rpc ports
+        for (const auto& inputRpcPortName : inputRPCPortsNamesVector) {
+            // Open a local port for the rpc data
+            yarp::os::RpcClient localRpcPort;
+            if (!localRpcPort.open("...")) {
+                yInfo() << logPrefix << "Failed to open local port";
+                return false;
             }
-            yInfo() << logPrefix << "Waiting connection with" << inputRpcPortName;
-            yarp::os::Time::delay(10);
+
+            // Wait the connection with the remote port
+            while (true) {
+                yarp::os::Network::connect(localRpcPort.getName(), inputRpcPortName);
+                if (yarp::os::Network::isConnected(localRpcPort.getName(), inputRpcPortName)) {
+                    yInfo() << logPrefix << "Connected with" << inputRpcPortName;
+                    break;
+                }
+                yInfo() << logPrefix << "Waiting connection with" << inputRpcPortName;
+                yarp::os::Time::delay(10);
+            }
+
+            // Attach the rpc client
+            wearable::msg::WearableMetadataService service;
+            if (!service.yarp().attachAsClient(localRpcPort)) {
+                yError() << logPrefix << "Failed to attach to" << localRpcPort.getName();
+                return false;
+            }
+
+            // Ask metadata and store them
+            metadata.push_back(service.getMetadata());
+
+            // Close the temporary port
+            localRpcPort.close();
         }
 
-        // Attach the rpc client
-        wearable::msg::WearableMetadataService service;
-        if (!service.yarp().attachAsClient(localRpcPort)) {
-            yError() << logPrefix << "Failed to attach to" << localRpcPort.getName();
+        // ====================================
+        // PROCESS METADATA READ FROM RPC PORTS
+        // ====================================
+        yDebug() << logPrefix << "Processing RPC metadata";
+
+        auto findStoredSensorName =
+            [](const std::string& name,
+               std::map<wearable::sensor::SensorType, std::vector<std::string>>& map) -> bool {
+            for (const auto& entryPair : map) {
+                for (const std::string& sensorName : entryPair.second) {
+                    if (sensorName == name) {
+                        return true;
+                    }
+                }
+            }
             return false;
-        }
+        };
 
-        // Ask metadata and store them
-        metadata.push_back(service.getMetadata());
+        // Store the sensor names checking that there are no name duplicates in the
+        // connected implementation of IWear
+        for (const WearableMetadata& wearableMetadataFromSingleSource : metadata) {
 
-        // Close the temporary port
-        localRpcPort.close();
-    }
+            for (const auto& mapEntry : wearableMetadataFromSingleSource) {
 
-    // ====================================
-    // PROCESS METADATA READ FROM RPC PORTS
-    // ====================================
-    yDebug() << logPrefix << "Processing RPC metadata";
+                const wearable::msg::SensorType& sensorType = mapEntry.first;
+                const SensorTypeMetadata& sensorTypeMetadata = mapEntry.second;
 
-    auto findStoredSensorName =
-        [](const std::string& name,
-           std::map<wearable::sensor::SensorType, std::vector<std::string>>& map) -> bool {
-        for (const auto& entryPair : map) {
-            for (const std::string& sensorName : entryPair.second) {
-                if (sensorName == name) {
-                    return true;
+                for (const wearable::msg::WearableSensorMetadata& sensorMD : sensorTypeMetadata) {
+                    // Check there isn't any sensor name collision
+                    if (findStoredSensorName(sensorMD.name, pImpl->rpcSensorNames)) {
+                        yError() << logPrefix << "Sensor with name " << sensorMD.name
+                                 << " alredy exists.";
+                        return false;
+                    }
+                    // Add the sensor name
+                    yInfo() << logPrefix << "Found sensor" << sensorMD.name;
+                    pImpl->rpcSensorNames[MapSensorType.at(sensorType)].push_back(sensorMD.name);
                 }
-            }
-        }
-        return false;
-    };
-
-    // Store the sensor names checking that there are no name duplicates in the
-    // connected implementation of IWear
-    for (const WearableMetadata& wearableMetadataFromSingleSource : metadata) {
-
-        for (const auto& mapEntry : wearableMetadataFromSingleSource) {
-
-            const wearable::msg::SensorType& sensorType = mapEntry.first;
-            const SensorTypeMetadata& sensorTypeMetadata = mapEntry.second;
-
-            for (const wearable::msg::WearableSensorMetadata& sensorMD : sensorTypeMetadata) {
-                // Check there isn't any sensor name collision
-                if (findStoredSensorName(sensorMD.name, pImpl->rpcSensorNames)) {
-                    yError() << logPrefix << "Sensor with name " << sensorMD.name
-                             << " alredy exists.";
-                    return false;
-                }
-                // Add the sensor name
-                yInfo() << logPrefix << "Found sensor" << sensorMD.name;
-                pImpl->rpcSensorNames[MapSensorType.at(sensorType)].push_back(sensorMD.name);
             }
         }
     }
@@ -946,7 +969,8 @@ IWearRemapper::impl::getSensor(const sensor::SensorName name,
                                const sensor::SensorType type,
                                std::map<std::string, SensorPtr<SensorImpl>>& storage)
 {
-    if (!validSensorName(name, type)) {
+    // TODO check if this check on the sensor name is required, and how it is done in case rpc is not available
+    if (useRPC && !validSensorName(name, type)) {
         yError() << logPrefix << "Sensor" << name << "not found in the list read from the wrapper";
         return nullptr;
     }


### PR DESCRIPTION
The `rpc` port of IWearRemapper can be enabled or disabled by using or not the `wearableRPCPorts` parameter.

(In addiction, with https://github.com/Yeshasvitvs/wearables/commit/5b643b3a3711a8db227c1454d6a4cce72167219f, instead of overriting the `BUILD_SHARED_LIBS` cmake option, we are using  `YARP_FORCE_DYNAMIC_PLUGINS` in order to compile the plugins as dynamic libraries analogously to what done in https://github.com/Yeshasvitvs/human-dynamics-estimation/blob/feature/humanstateprovider_multi_thread_ik/CMakeLists.txt#L50) 